### PR TITLE
Added bootJar step to gradle CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,3 +28,6 @@ jobs:
                   distribution: "adopt"
             - name: Build with Gradle
               run: ./gradlew API:build
+
+            - name: Create boot jar
+              run: ./gradlew bootJar

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -Dserver.port=$PORT -jar build/libs/*.jar
+web: java $JAVA_OPTS -Dserver.port=$PORT -jar API/build/libs/*.jar


### PR DESCRIPTION
- Fixed Heroku not being able to automatically deploy because of missing JAR file