### PR TITLE
22 (Role comparison is case sensitive)

### DIFF
--- a/UI/components/WithClientSideAuth.jsx
+++ b/UI/components/WithClientSideAuth.jsx
@@ -12,7 +12,9 @@ export default function WithClientSideAuth(WrappedComponent) {
         useEffect(() => {
             if (!role) return;
 
-            const mapped = roleRouteMappings.get(router.asPath).includes(role);
+            const mapped = roleRouteMappings
+                .get(router.asPath)
+                .includes(role.toLocaleLowerCase());
             if (!mapped) {
                 router.push("/login");
             }


### PR DESCRIPTION
### Changes

- Role comparison in `WithClientSideAuth` now case insensitive